### PR TITLE
Removed rep-o-matic requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "php": ">=7.0.0",
         "fideloper/proxy": "~3.3",
         "laravel/framework": "5.5.*",
-        "laravel/tinker": "~1.0",
-        "alextigaer/rep-o-matic": "1.*"
+        "laravel/tinker": "~1.0"
     },
     "require-dev": {
         "filp/whoops": "~2.0",


### PR DESCRIPTION
Removed rep-o-matic from "require" list to verify if the project can be installed without the "dev-master" option